### PR TITLE
Allow to select the k8s cluster context

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@
 | <a name="input_cloud_provider"></a> [cloud\_provider](#input\_cloud\_provider) | n/a | `string` | n/a | yes |
 | <a name="input_cluster_issuer_name"></a> [cluster\_issuer\_name](#input\_cluster\_issuer\_name) | n/a | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | n/a | `string` | n/a | yes |
-| <a name="input_config_path"></a> [config\_path](#input\_config\_path) | n/a | `string` | n/a | yes |
 | <a name="input_container_tag"></a> [container\_tag](#input\_container\_tag) | n/a | `string` | n/a | yes |
 | <a name="input_cost_center"></a> [cost\_center](#input\_cost\_center) | n/a | `string` | n/a | yes |
 | <a name="input_create_babylon"></a> [create\_babylon](#input\_create\_babylon) | n/a | `bool` | n/a | yes |
@@ -106,6 +105,8 @@
 | <a name="input_identifier_uri"></a> [identifier\_uri](#input\_identifier\_uri) | The platform identifier uri | `any` | n/a | yes |
 | <a name="input_image_path"></a> [image\_path](#input\_image\_path) | n/a | `string` | n/a | yes |
 | <a name="input_kubernetes_cluster_admin_activate"></a> [kubernetes\_cluster\_admin\_activate](#input\_kubernetes\_cluster\_admin\_activate) | n/a | `bool` | n/a | yes |
+| <a name="input_kubernetes_config_context"></a> [kubernetes\_config\_context](#input\_kubernetes\_config\_context) | n/a | `string` | n/a | yes |
+| <a name="input_kubernetes_config_path"></a> [kubernetes\_config\_path](#input\_kubernetes\_config\_path) | n/a | `string` | n/a | yes |
 | <a name="input_kubernetes_mc_resource_group_name"></a> [kubernetes\_mc\_resource\_group\_name](#input\_kubernetes\_mc\_resource\_group\_name) | n/a | `string` | n/a | yes |
 | <a name="input_kubernetes_resource_group"></a> [kubernetes\_resource\_group](#input\_kubernetes\_resource\_group) | n/a | `string` | n/a | yes |
 | <a name="input_kubernetes_tenant_namespace"></a> [kubernetes\_tenant\_namespace](#input\_kubernetes\_tenant\_namespace) | n/a | `string` | n/a | yes |

--- a/providers.tf
+++ b/providers.tf
@@ -25,7 +25,8 @@ terraform {
 }
 
 provider "kubernetes" {
-  config_path = var.config_path
+  config_path    = var.kubernetes_config_path
+  config_context = var.kubernetes_config_context
 }
 
 terraform {

--- a/terraform.auto.tfvars
+++ b/terraform.auto.tfvars
@@ -9,8 +9,6 @@ tenant_sp_object_id        = ""
 cloud_provider             = "azure"
 azure_prerequisites_deploy = false
 
-config_path = ""
-
 # project
 customer_name = "cosmotech"
 customertag   = ""
@@ -30,6 +28,8 @@ monitoring_namespace = "cosmotech-monitoring"
 monitoring_enabled   = true
 
 # kubernetes
+kubernetes_config_path            = ""
+kubernetes_config_context         = ""
 kubernetes_mc_resource_group_name = ""
 first_tenant_in_cluster           = false
 

--- a/variables.global.tf
+++ b/variables.global.tf
@@ -22,6 +22,3 @@ variable "services_secrets_create" {
 variable "cloud_provider" {
   type = string
 }
-variable "config_path" {
-  type = string
-}

--- a/variables.k8s.tf
+++ b/variables.k8s.tf
@@ -4,3 +4,9 @@ variable "kubernetes_mc_resource_group_name" {
 variable "kubernetes_cluster_admin_activate" {
   type = bool
 }
+variable "kubernetes_config_path" {
+  type = string
+}
+variable "kubernetes_config_context" {
+  type = string
+}


### PR DESCRIPTION
* I've renamed the `config_path` variable to `kubernetes_config_path`, this is a breaking change, let me know if this is an issue.
* I've moved the two k8s provider config variables to the `variables.k8s.tf` instead of the `global` one. Not sure if this is better, I can move them back if you have another logic for grouping the variables.